### PR TITLE
Fixed missing EditUserTextUrl in Comment.cs

### DIFF
--- a/RedditSharp/Comment.cs
+++ b/RedditSharp/Comment.cs
@@ -14,6 +14,8 @@ namespace RedditSharp
     {
         private const string CommentUrl = "/api/comment";
         private const string DistinguishUrl = "/api/distinguish";
+        private const string EditUserTextUrl = "/api/editusertext";
+
         [JsonIgnore]
         private Reddit Reddit { get; set; }
 


### PR DESCRIPTION
Fixed a build breaking bug where the constant EditUserTextUrl in Comment.cs was missing. This constant is used to edit comment text after it has been posted.
