### PR TITLE
Preliminary wiki support

### DIFF
--- a/RedditSharp/Listing.cs
+++ b/RedditSharp/Listing.cs
@@ -74,7 +74,7 @@ namespace RedditSharp
                 var children = json["data"]["children"] as JArray;
                 CurrentPage = new Thing[children.Count];
                 for (int i = 0; i < CurrentPage.Length; i++)
-                    CurrentPage[i] = Thing.Parse(Listing.Reddit, children[i], Listing.WebAgent);
+                    CurrentPage[i] = Thing.Parse<T>(Listing.Reddit, children[i], Listing.WebAgent);
                 After = json["data"]["after"].Value<string>();
                 Before = json["data"]["before"].Value<string>();
             }

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -39,8 +39,6 @@ namespace RedditSharp
 
         internal readonly IWebAgent _webAgent;
 
-        public IWebAgent MyWebAgent { get { return _webAgent; } }
-
         /// <summary>
         /// Captcha solver instance to use when solving captchas.
         /// </summary>

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -82,6 +82,10 @@
     <Compile Include="VotableThing.cs" />
     <Compile Include="RateLimitException.cs" />
     <Compile Include="WebAgent.cs" />
+    <Compile Include="Wiki.cs" />
+    <Compile Include="WikiPage.cs" />
+    <Compile Include="WikiPageRevision.cs" />
+    <Compile Include="WikiPageSettings.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RedditSharp/Subreddit.cs
+++ b/RedditSharp/Subreddit.cs
@@ -5,6 +5,7 @@ using System.Security.Authentication;
 using HtmlAgilityPack;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Net;
 
 namespace RedditSharp
 {
@@ -37,6 +38,9 @@ namespace RedditSharp
 
         [JsonIgnore]
         private IWebAgent WebAgent { get; set; }
+
+        [JsonIgnore]
+        public Wiki Wiki { get; private set; }
 
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
@@ -78,6 +82,7 @@ namespace RedditSharp
         {
             Reddit = reddit;
             WebAgent = webAgent;
+            Wiki = new Wiki(reddit, this, webAgent);
             JsonConvert.PopulateObject(json["data"].ToString(), this, reddit.JsonSerializerSettings);
             Name = Url;
             if (Name.StartsWith("/r/"))

--- a/RedditSharp/Thing.cs
+++ b/RedditSharp/Thing.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
 
 namespace RedditSharp
 {
@@ -22,6 +23,20 @@ namespace RedditSharp
                 default:
                     return null;
             }
+        }
+
+        // if we can't determine the type of thing by "kind", try by type
+        public static Thing Parse<T>(Reddit reddit, JToken json, IWebAgent webAgent) where T : Thing
+        {
+            Thing result = Parse(reddit, json, webAgent);
+            if (result == null)
+            {
+                if (typeof(T) == typeof(WikiPageRevision))
+                {
+                    return new WikiPageRevision(reddit, json, webAgent);
+                }
+            }
+            return result;
         }
 
         internal Thing(JToken json)

--- a/RedditSharp/Wiki.cs
+++ b/RedditSharp/Wiki.cs
@@ -1,0 +1,144 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RedditSharp
+{
+    public class Wiki
+    {
+        private Reddit Reddit { get; set; }
+        private Subreddit Subreddit { get; set; }
+        private IWebAgent WebAgent { get; set; }
+
+        private const string GetWikiPageUrl = "/r/{0}/wiki/{1}.json?v={2}";
+        private const string GetWikiPagesUrl = "/r/{0}/wiki/pages.json";
+        private const string WikiPageEditUrl = "/r/{0}/api/wiki/edit";
+        private const string HideWikiPageUrl = "/r/{0}/api/wiki/hide";
+        private const string RevertWikiPageUrl = "/r/{0}/api/wiki/revert";
+        private const string WikiPageAllowEditorAddUrl = "/r/{0}/api/wiki/alloweditor/add";
+        private const string WikiPageAllowEditorDelUrl = "/r/{0}/api/wiki/alloweditor/del";
+        private const string WikiPageSettingsUrl = "/r/{0}/wiki/settings/{1}.json";
+        private const string WikiRevisionsUrl = "/r/{0}/wiki/revisions.json";
+        private const string WikiPageRevisionsUrl = "/r/{0}/wiki/revisions/{1}.json";
+        private const string WikiPageDiscussionsUrl = "/r/{0}/wiki/discussions/{1}.json";
+
+        protected internal Wiki(Reddit reddit, Subreddit subreddit, IWebAgent webAgent)
+        {
+            Reddit = reddit;
+            Subreddit = subreddit;
+            WebAgent = webAgent;
+        }
+
+        public IEnumerable<string> GetPageNames()
+        {
+            var request = WebAgent.CreateGet(string.Format(GetWikiPagesUrl, Subreddit.Name));
+            var response = request.GetResponse();
+            string json = WebAgent.GetResponseString(response.GetResponseStream());
+            return JObject.Parse(json)["data"].Values<string>();
+        }
+
+        public WikiPage GetPage(string page, string version = null)
+        {
+            var request = WebAgent.CreateGet(string.Format(GetWikiPageUrl, Subreddit.Name, page, version));
+            var response = request.GetResponse();
+            var json = JObject.Parse(WebAgent.GetResponseString(response.GetResponseStream()));
+            var result = new WikiPage(Reddit, json["data"], WebAgent);
+            return result;
+        }
+
+        #region Settings
+        public WikiPageSettings GetPageSettings(string name)
+        {
+            var request = WebAgent.CreateGet(string.Format(WikiPageSettingsUrl, Subreddit.Name, name));
+            var response = request.GetResponse();
+            var json = JObject.Parse(WebAgent.GetResponseString(response.GetResponseStream()));
+            var result = new WikiPageSettings(Reddit, json["data"], WebAgent);
+            return result;
+        }
+
+        public void SetPageSettings(string name, WikiPageSettings settings)
+        {
+            var request = WebAgent.CreatePost(string.Format(WikiPageSettingsUrl, Subreddit.Name, name));
+            WebAgent.WritePostBody(request.GetRequestStream(), new
+            {
+                page = name,
+                permlevel = settings.PermLevel,
+                listed = settings.Listed,
+                uh = Reddit.User.Modhash
+            });
+            var response = request.GetResponse();
+        }
+        #endregion
+
+        #region Revisions
+        public Listing<WikiPageRevision> GetRevisions()
+        {
+            return new Listing<WikiPageRevision>(Reddit, string.Format(WikiRevisionsUrl, Subreddit.Name), WebAgent);
+        }
+
+        public Listing<WikiPageRevision> GetPageRevisions(string page)
+        {
+            return new Listing<WikiPageRevision>(Reddit, string.Format(WikiPageRevisionsUrl, Subreddit.Name, page), WebAgent);
+        }
+        #endregion
+
+        #region Discussions
+        public Listing<Post> GetPageDiscussions(string page)
+        {
+            return new Listing<Post>(Reddit, string.Format(WikiPageDiscussionsUrl, Subreddit.Name, page), WebAgent);
+        }
+        #endregion
+
+        public void EditPage(string page, string content, string previous = null, string reason = null)
+        {
+            var request = WebAgent.CreatePost(string.Format(WikiPageEditUrl, Subreddit.Name));
+            WebAgent.WritePostBody(request.GetRequestStream(), new
+            {
+                content = content,
+                previous = previous,
+                reason = reason,
+                page = page,
+                uh = Reddit.User.Modhash
+            });
+            var response = request.GetResponse();
+        }
+
+        public void HidePage(string page, string revision)
+        {
+            var request = WebAgent.CreatePost(string.Format(HideWikiPageUrl, Subreddit.Name));
+            WebAgent.WritePostBody(request.GetRequestStream(), new
+            {
+                page = page,
+                revision = revision,
+                uh = Reddit.User.Modhash
+            });
+            var response = request.GetResponse();
+        }
+
+        public void RevertPage(string page, string revision)
+        {
+            var request = WebAgent.CreatePost(string.Format(RevertWikiPageUrl, Subreddit.Name));
+            WebAgent.WritePostBody(request.GetRequestStream(), new
+            {
+                page = page,
+                revision = revision,
+                uh = Reddit.User.Modhash
+            });
+            var response = request.GetResponse();
+        }
+
+        public void SetPageEditor(string page, string username, bool allow)
+        {
+            var request = WebAgent.CreatePost(string.Format(allow ? WikiPageAllowEditorAddUrl : WikiPageAllowEditorDelUrl, Subreddit.Name));
+            WebAgent.WritePostBody(request.GetRequestStream(), new
+            {
+                page = page,
+                username = username,
+                uh = Reddit.User.Modhash
+            });
+            var response = request.GetResponse();
+        }
+
+        
+    }
+}

--- a/RedditSharp/WikiPage.cs
+++ b/RedditSharp/WikiPage.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace RedditSharp
+{
+    public class WikiPage
+    {
+        [JsonProperty("may_revise")]
+        public string MayRevise { get; set; }
+
+        [JsonProperty("revision_date")]
+        [JsonConverter(typeof(UnixTimestampConverter))]
+        public DateTime? RevisionDate { get; set; }
+
+        [JsonProperty("content_html")]
+        public string HtmlContent { get; set; }
+
+        [JsonProperty("content_md")]
+        public string MarkdownContent { get; set; }
+
+        [JsonIgnore]
+        public RedditUser RevisionBy { get; set; }
+
+        protected internal WikiPage(Reddit reddit, JToken json, IWebAgent webAgent)
+        {
+            RevisionBy = new RedditUser(reddit, json["revision_by"], webAgent);
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
+        }
+    }
+}

--- a/RedditSharp/WikiPageRevision.cs
+++ b/RedditSharp/WikiPageRevision.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace RedditSharp
+{
+    public class WikiPageRevision : Thing
+    {
+        [JsonProperty("id")]
+        public string Id { get; private set; }
+
+        [JsonProperty("timestamp")]
+        [JsonConverter(typeof(UnixTimestampConverter))]
+        public DateTime? TimeStamp { get; set; }
+
+        [JsonProperty("reason")]
+        public string Reason { get; private set; }
+
+        [JsonProperty("page")]
+        public string Page { get; private set; }
+
+        [JsonIgnore]
+        public RedditUser Author { get; set; }
+
+        protected internal WikiPageRevision(Reddit reddit, JToken json, IWebAgent webAgent)
+            : base(null)
+        {
+            Author = new RedditUser(reddit, json["author"], webAgent);
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
+        }
+    }
+}

--- a/RedditSharp/WikiPageSettings.cs
+++ b/RedditSharp/WikiPageSettings.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RedditSharp
+{
+    public class WikiPageSettings
+    {
+        [JsonProperty("listed")]
+        public bool Listed { get; set; }
+
+        [JsonProperty("permlevel")]
+        public int PermLevel { get; set; }
+
+        [JsonIgnore]
+        public IEnumerable<RedditUser> Editors { get; set; }
+
+        public WikiPageSettings()
+        {
+        }
+
+        protected internal WikiPageSettings(Reddit reddit, JToken json, IWebAgent webAgent)
+        {
+            var editors = json["editors"].ToArray();
+            Editors = editors.Select(x =>
+            {
+                return new RedditUser(reddit, x, webAgent);
+            });
+            JsonConvert.PopulateObject(json.ToString(), this, reddit.JsonSerializerSettings);
+        }
+    }
+}


### PR DESCRIPTION
Everything is here, except wiki page revision diffs which i don't think have support in the public api. Everything is in a new Wiki object in the Subreddit class.

The only modification to existing code is in the Thing class.  I had to add parsing by generic type (Parse<T>) so I could get Listing support for Things that aren't "Things" like page revisions.  Slight change to Listing to call the generic Parse function. There may have been a easier/better way to do this.
