### PR TITLE
Fix GetThingByFullname() and Post.Comment()

### DIFF
--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -23,7 +23,7 @@ namespace RedditSharp
         private const string SubredditAboutUrl = "/r/{0}/about.json";
         private const string ComposeMessageUrl = "/api/compose";
         private const string RegisterAccountUrl = "/api/register";
-        private const string GetThingUrl = "/by_id/{0}.json";
+        private const string GetThingUrl = "/api/info.json?id={0}";
         private const string GetCommentUrl = "/r/{0}/comments/{1}/foo/{2}.json";
         private const string GetPostUrl = "{0}.json";
         private const string DomainUrl = "www.reddit.com";

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -162,7 +162,7 @@ namespace RedditSharp.Things
             if (json["json"]["ratelimit"] != null)
                 throw new RateLimitException(TimeSpan.FromSeconds(json["json"]["ratelimit"].ValueOrDefault<double>()));
             var comment = json["json"]["data"]["things"][0];
-            return new Comment().Init(Reddit, comment, WebAgent, this);
+            (Comment)Reddit.GetThingByFullname((string)comment["data"]["id"]); //Ugly way to do it because we need to make 2 requests, but it works
         }
 
         private string SimpleAction(string endpoint)

--- a/TestRedditSharp/Program.cs
+++ b/TestRedditSharp/Program.cs
@@ -46,7 +46,7 @@ namespace TestRedditSharp
                     }
                 }
             }
-            Console.Write("Create post? (y/n) [n]: ");
+            /*Console.Write("Create post? (y/n) [n]: ");
             var choice = Console.ReadLine();
             if (!string.IsNullOrEmpty(choice) && choice.ToLower()[0] == 'y')
             {
@@ -64,7 +64,14 @@ namespace TestRedditSharp
                 var sub = reddit.GetSubreddit(subname);
                 foreach (var post in sub.GetTop(FromTime.Week).Take(10))
                     Console.WriteLine("\"{0}\" by {1}", post.Title, post.Author);
-            }
+            }*/
+            Comment comment = (Comment)reddit.GetThingByFullname("t1_ciif2g7");
+            Post post = (Post)reddit.GetThingByFullname("t3_298g7j");
+            PrivateMessage pm = (PrivateMessage)reddit.GetThingByFullname("t4_20oi3a"); // Use your own PM here, as you don't have permission to view this one
+            Console.WriteLine(comment.Body);
+            Console.WriteLine(post.Title);
+            Console.WriteLine(pm.Body);
+            Console.WriteLine(post.Comment("test").FullName);
             Console.ReadKey(true);
         }
 


### PR DESCRIPTION
Fixes GetThingByFullname() only working on comments, not posts
Fixes Post.Comment() returning a basically empty object (Closes #116)
Adds tests to prove both of the above function correctly
