### PR TITLE
Fixed NullReferenceException

### DIFF
--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -93,22 +93,19 @@ namespace RedditSharp
             CaptchaSolver = new ConsoleCaptchaSolver();
         }
 
-        public Reddit(WebAgent.RateLimitMode limitMode)
-            : this()
+        public Reddit(WebAgent.RateLimitMode limitMode) : this()
         {
             WebAgent.UserAgent = "";
             WebAgent.RateLimit = limitMode;
             WebAgent.RootDomain = "www.reddit.com";
         }
 
-        public Reddit(string username, string password, bool useSsl = true)
-            : this()
+        public Reddit(string username, string password, bool useSsl = true) : this()
         {
             LogIn(username, password, useSsl);
         }
 
-        public Reddit(string accessToken)
-            : this()
+        public Reddit(string accessToken) : this()
         {
             WebAgent.Protocol = "https";
             WebAgent.RootDomain = OAuthDomainUrl;


### PR DESCRIPTION
Not calling the default constructor from the overload on [line 96](https://github.com/SirCmpwn/RedditSharp/blob/master/RedditSharp/Reddit.cs#L96) was causing `NullReferenceException` when calling most of the instance methods.
