### PR TITLE
Fix for a bug related to removing posts.

### DIFF
--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -224,27 +224,22 @@ namespace RedditSharp.Things
 
         public void Remove()
         {
-            var request = WebAgent.CreatePost(RemoveUrl);
-            var stream = request.GetRequestStream();
-            WebAgent.WritePostBody(stream, new
-            {
-                id = FullName,
-                spam = false,
-                uh = Reddit.User.Modhash
-            });
-            stream.Close();
-            var response = request.GetResponse();
-            var data = WebAgent.GetResponseString(response.GetResponseStream());
+            RemoveImpl(false);
         }
 
         public void RemoveSpam()
+        {
+            RemoveImpl(true);
+        }
+
+        private void RemoveImpl(bool spam)
         {
             var request = WebAgent.CreatePost(RemoveUrl);
             var stream = request.GetRequestStream();
             WebAgent.WritePostBody(stream, new
             {
                 id = FullName,
-                spam = true,
+                spam = spam,
                 uh = Reddit.User.Modhash
             });
             stream.Close();

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -178,17 +178,22 @@ namespace RedditSharp.Things
 
         public void Remove()
         {
-            var data = SimpleAction(RemoveUrl);
+            RemoveImpl(false);
         }
 
         public void RemoveSpam()
+        {
+            RemoveImpl(true);
+        }
+
+        private void RemoveImpl(bool spam)
         {
             var request = WebAgent.CreatePost(RemoveUrl);
             var stream = request.GetRequestStream();
             WebAgent.WritePostBody(stream, new
             {
                 id = FullName,
-                spam = true,
+                spam = spam,
                 uh = Reddit.User.Modhash
             });
             stream.Close();


### PR DESCRIPTION
- Fixed `Post.Remove()` erroneously removing as spam (thanks to reddit user [/u/EorEquis](http://www.reddit.com/user/EorEquis) for bringing this to light).
- Cleaned up the removal code in `Comment.cs` and `Post.cs`.
