### PR TITLE
Added GetOAuthToken for script apps

### DIFF
--- a/RedditSharp/AuthProvider.cs
+++ b/RedditSharp/AuthProvider.cs
@@ -117,13 +117,14 @@ namespace RedditSharp
             throw new AuthenticationException("Could not log in.");
         }
 
-		/// <summary>
+        /// <summary>
         /// Gets the OAuth token for the user.
         /// </summary>
         /// <param name="username">The username.</param>
         /// <param name="password">The user's password.</param>
         /// <returns>The access token</returns>
-        public string GetOAuthToken(string username, string password) {
+        public string GetOAuthToken(string username, string password) 
+	    {
             if (Type.GetType("Mono.Runtime") != null)
                 ServicePointManager.ServerCertificateValidationCallback = (s, c, ch, ssl) => true;
             _webAgent.Cookies = new CookieContainer();
@@ -133,7 +134,8 @@ namespace RedditSharp
             request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
             var stream = request.GetRequestStream();
 
-            _webAgent.WritePostBody(stream, new {
+            _webAgent.WritePostBody(stream, new 
+		    {
                 grant_type = "password",
                 username,
                 password,
@@ -142,7 +144,8 @@ namespace RedditSharp
 
             stream.Close();
             var json = _webAgent.ExecuteRequest(request);
-            if (json["access_token"] != null) {
+            if (json["access_token"] != null) 
+		    {
                 if (json["refresh_token"] != null)
                     RefreshToken = json["refresh_token"].ToString();
                 OAuthToken = json["access_token"].ToString();

--- a/RedditSharp/AuthProvider.cs
+++ b/RedditSharp/AuthProvider.cs
@@ -123,8 +123,8 @@ namespace RedditSharp
         /// <param name="username">The username.</param>
         /// <param name="password">The user's password.</param>
         /// <returns>The access token</returns>
-        public string GetOAuthToken(string username, string password) 
-	    {
+        public string GetOAuthToken(string username, string password)
+        {
             if (Type.GetType("Mono.Runtime") != null)
                 ServicePointManager.ServerCertificateValidationCallback = (s, c, ch, ssl) => true;
             _webAgent.Cookies = new CookieContainer();
@@ -134,8 +134,8 @@ namespace RedditSharp
             request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
             var stream = request.GetRequestStream();
 
-            _webAgent.WritePostBody(stream, new 
-		    {
+            _webAgent.WritePostBody(stream, new
+            {
                 grant_type = "password",
                 username,
                 password,
@@ -144,8 +144,8 @@ namespace RedditSharp
 
             stream.Close();
             var json = _webAgent.ExecuteRequest(request);
-            if (json["access_token"] != null) 
-		    {
+            if (json["access_token"] != null)
+            {
                 if (json["refresh_token"] != null)
                     RefreshToken = json["refresh_token"].ToString();
                 OAuthToken = json["access_token"].ToString();

--- a/RedditSharp/AuthProvider.cs
+++ b/RedditSharp/AuthProvider.cs
@@ -117,6 +117,40 @@ namespace RedditSharp
             throw new AuthenticationException("Could not log in.");
         }
 
+		/// <summary>
+        /// Gets the OAuth token for the user.
+        /// </summary>
+        /// <param name="username">The username.</param>
+        /// <param name="password">The user's password.</param>
+        /// <returns>The access token</returns>
+        public string GetOAuthToken(string username, string password) {
+            if (Type.GetType("Mono.Runtime") != null)
+                ServicePointManager.ServerCertificateValidationCallback = (s, c, ch, ssl) => true;
+            _webAgent.Cookies = new CookieContainer();
+
+            var request = _webAgent.CreatePost(AccessUrl);
+
+            request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
+            var stream = request.GetRequestStream();
+
+            _webAgent.WritePostBody(stream, new {
+                grant_type = "password",
+                username,
+                password,
+                redirect_uri = _redirectUri
+            });
+
+            stream.Close();
+            var json = _webAgent.ExecuteRequest(request);
+            if (json["access_token"] != null) {
+                if (json["refresh_token"] != null)
+                    RefreshToken = json["refresh_token"].ToString();
+                OAuthToken = json["access_token"].ToString();
+                return json["access_token"].ToString();
+            }
+            throw new AuthenticationException("Could not log in.");
+        }
+		
         /// <summary>
         /// Gets a user authenticated by OAuth2.
         /// </summary>


### PR DESCRIPTION
Added GetOAuthToken for script apps (i.e. apps that don't have a code to use with the other GetOAuthToken),

Usage:

    AuthProvider auth = new AuthProvider("client_id", "client_secret", "redirect_url");

    var token = auth.GetOAuthToken("reddit_bot", "bot_password");

    Reddit reddit = new Reddit(token);