### PR TITLE
Fixed Shortlink from throwing exception if Comment.Parent is null.

### DIFF
--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -123,9 +123,16 @@ namespace RedditSharp.Things
             get
             {
                 // Not really a "short" link, but you can't actually use short links for comments
+                string linkId = "";
+                int index = this.LinkId.IndexOf('_');
+                if (index > -1)
+                {
+                    linkId = this.LinkId.Substring(index + 1);
+                }
+
                 return String.Format("{0}://{1}/r/{2}/comments/{3}/_/{4}",
                                      RedditSharp.WebAgent.Protocol, RedditSharp.WebAgent.RootDomain,
-                                     this.Subreddit, this.Parent.Id, this.Id);
+                                     this.Subreddit, this.Parent != null ? this.Parent.Id : linkId, this.Id);
             }
         }
 


### PR DESCRIPTION
If Comment.Parent is null, the call to comment.Shortlink would throw an exception.

I've added a null-check on the Comment.Parent property, allowing it to use the Comment.LinkId as a fallback option. This continues to provide the correct permalink to the comment.