### PR TITLE
Allow precompiled binaries in "Release" folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bin/
+Debug/
 obj/
 *.user
 *.userprefs


### PR DESCRIPTION
Please keep the "no binary" crap to the linux world. In Windows we provide binaries (you build them anyways).
Changing this line allows binaries from the "Release" folder to be added to the repository. If you want people to use your library, actually provide it.

I could not use the library because I lack the required visual studio version.