### PR TITLE
Resolving issue 151 - SetFlair throwing exception

### DIFF
--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -302,10 +302,9 @@ namespace RedditSharp.Things
             WebAgent.WritePostBody(request.GetRequestStream(), new
             {
                 api_type = "json",
-                r = Subreddit,
                 css_class = flairClass,
                 link = FullName,
-                //name = Name,
+                name = Reddit.User.Name,
                 text = flairText,
                 uh = Reddit.User.Modhash
             });

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -116,9 +116,6 @@ namespace RedditSharp.Things
         [JsonProperty("selftext_html")]
         public string SelfTextHtml { get; set; }
 
-        [JsonProperty("subreddit")]
-        public string Subreddit { get; set; }
-
         [JsonProperty("thumbnail")]
         [JsonConverter(typeof(UrlParser))]
         public Uri Thumbnail { get; set; }


### PR DESCRIPTION
SetFlair was implemented incorrectly. Subreddit is supplied via url and it was not supplying a name value. Blame did not reveal why it was this way due to a major refactoring made in 2014.