### PR TITLE
Added RateLimitMode.SmallBurst as middle ground option

### DIFF
--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -152,7 +152,7 @@ namespace RedditSharp
                     if (_requestsThisBurst >= 5) //limit has been reached
                     {
                         while ((DateTime.UtcNow - _burstStart).TotalSeconds < 10)
-                            Thread.Sleep(100);
+                            Thread.Sleep(250);
                         _burstStart = DateTime.UtcNow;
                     }
                     _requestsThisBurst++;

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -42,6 +42,10 @@ namespace RedditSharp
             /// </summary>
             Pace,
             /// <summary>
+            /// Restricts requests to five per ten seconds
+            /// </summary>
+            SmallBurst,
+            /// <summary>
             /// Restricts requests to thirty per minute
             /// </summary>
             Burst,
@@ -141,6 +145,17 @@ namespace RedditSharp
                     while ((DateTime.UtcNow - _lastRequest).TotalSeconds < 2)// Rate limiting
                         Thread.Sleep(250);
                     _lastRequest = DateTime.UtcNow;
+                    break;
+                case RateLimitMode.SmallBurst:
+                    if (_requestsThisBurst == 0)//this is first request
+                        _burstStart = DateTime.UtcNow;
+                    if (_requestsThisBurst >= 5) //limit has been reached
+                    {
+                        while ((DateTime.UtcNow - _burstStart).TotalSeconds < 10)
+                            Thread.Sleep(100);
+                        _burstStart = DateTime.UtcNow;
+                    }
+                    _requestsThisBurst++;
                     break;
                 case RateLimitMode.Burst:
                     if (_requestsThisBurst == 0)//this is first request


### PR DESCRIPTION
RateLimitMode.Pace seems like it causes a lot of unneeded delays for most cases, but RateLimitMode.Burst option can cause a very long lockout to the user / program as well. I think having a nice middle ground of 5 requests every 10 seconds would be nice and it has no negative impact.