### PR TITLE
Remove bug and race condition from EnforceRateLimit

### DIFF
--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Web;
@@ -137,6 +138,7 @@ namespace RedditSharp
 
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         private static void EnforceRateLimit()
         {
             switch (RateLimit)
@@ -154,6 +156,7 @@ namespace RedditSharp
                         while ((DateTime.UtcNow - _burstStart).TotalSeconds < 10)
                             Thread.Sleep(250);
                         _burstStart = DateTime.UtcNow;
+                        _requestsThisBurst = 0;
                     }
                     _requestsThisBurst++;
                     break;
@@ -165,6 +168,7 @@ namespace RedditSharp
                         while ((DateTime.UtcNow - _burstStart).TotalSeconds < 60)
                             Thread.Sleep(250);
                         _burstStart = DateTime.UtcNow;
+                        _requestsThisBurst = 0;
                     }
                     _requestsThisBurst++;
                     break;


### PR DESCRIPTION
Not resetting _requestsThisBurst meant that after 30 calls to the Reddit API you would only be able to make one call per minute. I fixed this by resetting _requestsThisBurst to 0 when _burstStart is reset.

Not making the method synchronized meant that there existed a race condition where more than 30 requests would be transmitted every 60 seconds. This can be exhibited by printing _requestsThisBurst on every EnforceRateLimit call and making a demo program that calls the API many times in parallel, for example:

var posts = reddit.GetSubreddit("askreddit").Hot.Take(100);
Parallel.ForEach(posts, post =>
{
    var topCommentAuthor = post.Comments.FirstOrDefault().Author
});