### PR TITLE
Search and Post's subreddit function.

### DIFF
--- a/RedditSharp/Listing.cs
+++ b/RedditSharp/Listing.cs
@@ -5,6 +5,24 @@ using RedditSharp.Things;
 
 namespace RedditSharp
 {
+    public enum Sorting
+    {
+        Relevance,
+        New,
+        Top,
+        Comments
+    }
+
+    public enum TimeSorting
+    {
+        All,
+        Hour,
+        Day,
+        Week,
+        Month,
+        Year
+    }
+
     public class Listing<T> : IEnumerable<T> where T : Thing
     {
         /// <summary>

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -356,8 +356,10 @@ namespace RedditSharp
             return Search<T>(urlSearchQuery);
         }
 
-        public Listing<T> Search<T>(string query, Sorting sort = Sorting.Relevance, TimeSorting time = TimeSorting.All) where T : Thing
+        public Listing<T> Search<T>(string query, Sorting sortE = Sorting.Relevance, TimeSorting timeE = TimeSorting.All) where T : Thing
         {
+            string sort = sortE.ToString().ToLower();
+            string time = timeE.ToString().ToLower();
             return new Listing<T>(this, string.Format(SearchUrl, query, sort, time), _webAgent);
         }
 

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -356,9 +356,9 @@ namespace RedditSharp
             return Search<T>(urlSearchQuery);
         }
 
-        public Listing<T> Search<T>(string query) where T : Thing
+        public Listing<T> Search<T>(string query, Sorting sort = Sorting.Relevance, TimeSorting time = TimeSorting.All) where T : Thing
         {
-            return new Listing<T>(this, string.Format(SearchUrl, query, "relevance", "all"), _webAgent);
+            return new Listing<T>(this, string.Format(SearchUrl, query, sort, time), _webAgent);
         }
 
         #region Helpers

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
@@ -150,6 +151,14 @@ namespace RedditSharp.Things
             if (json["json"]["ratelimit"] != null)
                 throw new RateLimitException(TimeSpan.FromSeconds(json["json"]["ratelimit"].ValueOrDefault<double>()));
             return new Comment().Init(Reddit, json["json"]["data"]["things"][0], WebAgent, this);
+        }
+
+        public string GetSubreddit()
+        {
+            Reddit reddit = new Reddit();
+            string substring = Permalink.ToString();
+            Match match = Regex.Match(substring, @"/r/.*?(?=/)");
+            return match.Value;
         }
 
         private string SimpleAction(string endpoint)

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -124,7 +124,16 @@ namespace RedditSharp.Things
         public string Title { get; set; }
 
         [JsonProperty("subreddit")]
-        public string Subreddit { get; set; }
+        public string SubredditName { get; set; }
+
+        [JsonIgnore]
+        public Subreddit GetSubreddit
+        {
+            get
+            {
+                return Reddit.GetSubreddit("/r/" + SubredditName);
+            }
+        }
 
         [JsonProperty("url")]
         [JsonConverter(typeof(UrlParser))]

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
@@ -124,6 +123,9 @@ namespace RedditSharp.Things
         [JsonProperty("title")]
         public string Title { get; set; }
 
+        [JsonProperty("subreddit")]
+        public string Subreddit { get; set; }
+
         [JsonProperty("url")]
         [JsonConverter(typeof(UrlParser))]
         public Uri Url { get; set; }
@@ -151,14 +153,6 @@ namespace RedditSharp.Things
             if (json["json"]["ratelimit"] != null)
                 throw new RateLimitException(TimeSpan.FromSeconds(json["json"]["ratelimit"].ValueOrDefault<double>()));
             return new Comment().Init(Reddit, json["json"]["data"]["things"][0], WebAgent, this);
-        }
-
-        public string GetSubreddit()
-        {
-            Reddit reddit = new Reddit();
-            string substring = Permalink.ToString();
-            Match match = Regex.Match(substring, @"/r/.*?(?=/)");
-            return match.Value;
         }
 
         private string SimpleAction(string endpoint)

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -127,7 +127,7 @@ namespace RedditSharp.Things
         public string SubredditName { get; set; }
 
         [JsonIgnore]
-        public Subreddit GetSubreddit
+        public Subreddit Subreddit
         {
             get
             {


### PR DESCRIPTION
Added a Function for Post where it gets the post's subreddit,
and a function for searching.

I added two enums, one that is called Sorting and the other is called TimeSorting. 

```C#
public enum Sorting
    {
        Relevance,
        New,
        Top,
        Comments
    }

    public enum TimeSorting
    {
        All,
        Hour,
        Day,
        Week,
        Month,
        Year
    }
```

The search function still works if you update it, since it has it's default value on what it used to be, but you can use the function now like so:
```C#
var posts = redditbot.Search<Post>(searchQuery, Sorting.Top, TimeSorting.Month).Take<Post>(25);
```

The GetSubreddit simply returns a string, which you can use like this:
```C#
foreach(var post in allPosts)
            {
                if (SubredditsToIgnore.Any(s=>post.GetSubreddit().StartsWith(s)))
                {
                    Log.Add("Ignored post because it had an ignored subreddit: " + Environment.NewLine + "\t" + post.Title);
                    continue;
                };
            }
```

Simply ```post.GetSubreddit()```.
It uses Regex, acquiring the Subreddit string from the Permalink.