### PR TITLE
Add functionality to read / parse Moderator Toolbox Usernotes from wiki

### DIFF
--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -96,6 +96,9 @@
     <Compile Include="Things\WikiPageRevision.cs" />
     <Compile Include="WikiPageSettings.cs" />
     <Compile Include="Domain.cs" />
+	<Compile Include="tbUserNote.cs" />
+	<Compile Include="ToolBoxUserNotes.cs" />
+    <Compile Include="ToolBoxUserNotesException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -96,8 +96,8 @@
     <Compile Include="Things\WikiPageRevision.cs" />
     <Compile Include="WikiPageSettings.cs" />
     <Compile Include="Domain.cs" />
-	<Compile Include="tbUserNote.cs" />
-	<Compile Include="ToolBoxUserNotes.cs" />
+    <Compile Include="TBUserNote.cs" />
+    <Compile Include="ToolBoxUserNotes.cs" />
     <Compile Include="ToolBoxUserNotesException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -264,7 +264,7 @@ namespace RedditSharp.Things
             }
         }
 
-        public IEnumerable<tbUserNote> UserNotes
+        public IEnumerable<TBUserNote> UserNotes
         {
             get
             {

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -264,6 +264,14 @@ namespace RedditSharp.Things
             }
         }
 
+        public IEnumerable<tbUserNote> UserNotes
+        {
+            get
+            {
+                return ToolBoxUserNotes.GetUserNotes(WebAgent, Name);
+            }
+        }
+
         public Subreddit Init(Reddit reddit, JToken json, IWebAgent webAgent)
         {
             CommonInit(reddit, json, webAgent);

--- a/RedditSharp/ToolBoxUserNotes.cs
+++ b/RedditSharp/ToolBoxUserNotes.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO.Compression;
+
+namespace RedditSharp
+{
+    public static class ToolBoxUserNotes
+    {
+        private const string ToolBoxUserNotesWiki = "/r/{0}/wiki/usernotes";
+        public static IEnumerable<tbUserNote> GetUserNotes( IWebAgent webAgent, string subName)
+        {
+            var request = webAgent.CreateGet(String.Format(ToolBoxUserNotesWiki, subName));
+            var reqResponse = webAgent.ExecuteRequest(request);
+            var response = JObject.Parse(reqResponse["data"]["content_md"].Value<string>());
+
+            int version = response["ver"].Value<int>();
+            string[] mods = response["constants"]["users"].Values<string>().ToArray();
+
+            string[] warnings = response["constants"]["warnings"].Values<string>().ToArray();
+
+            if (version < 6)
+            {
+                throw new ToolBoxUserNotesException("Unsupported ToolBox version");
+            }
+            try {
+                var data = Convert.FromBase64String(response["blob"].Value<string>());
+
+                string uncompressed;
+                using (System.IO.MemoryStream compressedStream = new System.IO.MemoryStream(data))
+                {
+                    compressedStream.ReadByte();
+                    compressedStream.ReadByte(); //skips first to bytes to fix zlib block size
+                    using (DeflateStream blobStream = new DeflateStream(compressedStream, CompressionMode.Decompress))
+                    {
+                        using (var decompressedReader = new System.IO.StreamReader(blobStream))
+                        {
+                            uncompressed = decompressedReader.ReadToEnd();
+                        }
+
+                    }
+                }
+
+                JObject users = JObject.Parse(uncompressed);
+
+                List<tbUserNote> toReturn = new List<tbUserNote>();
+                foreach (KeyValuePair<string, JToken> user in users)
+                {
+                    var x = user.Value;
+                    foreach (JToken note in x["ns"].Children())
+                    {
+
+                        tbUserNote uNote = new tbUserNote();
+                        uNote.AppliesToUsername = user.Key;
+                        uNote.SubName = subName;
+                        uNote.SubmitterIndex = note["m"].Value<int>();
+                        uNote.Submitter = mods[uNote.SubmitterIndex];
+                        uNote.NoteTypeIndex = note["w"].Value<int>();
+                        uNote.NoteType = warnings[uNote.NoteTypeIndex];
+                        uNote.Message = note["n"].Value<string>();
+                        uNote.Timestamp = UnixTimeStamp.UnixTimeStampToDateTime(note["t"].Value<long>());
+                        uNote.Url = UnsquashLink(subName, note["l"].ValueOrDefault<string>());
+
+                        toReturn.Add(uNote);
+                    }
+                }
+                return toReturn;
+            }
+            catch(Exception e)
+            {
+                throw new ToolBoxUserNotesException("An error occured while processing Usernotes wiki. See inner exception for details", e);
+            }
+            
+        }
+        public static string UnsquashLink(string subreddit,string permalink)
+        {
+
+            var link = "https://reddit.com/r/" + subreddit + "/";
+            if (string.IsNullOrEmpty(permalink)) {
+                return link;
+            }
+            var linkParams = permalink.Split(',');
+
+            if (linkParams[0] == "l")
+            {
+                link += "comments/" + linkParams[1] + "/";
+                if (linkParams.Length > 2)
+                    link += "-/" + linkParams[2] + "/";
+            }
+            else if (linkParams[0] == "m")
+            {
+                link += "message/messages/" + linkParams[1];
+            }
+
+            return link;
+        }
+    }
+}

--- a/RedditSharp/ToolBoxUserNotes.cs
+++ b/RedditSharp/ToolBoxUserNotes.cs
@@ -11,7 +11,7 @@ namespace RedditSharp
     public static class ToolBoxUserNotes
     {
         private const string ToolBoxUserNotesWiki = "/r/{0}/wiki/usernotes";
-        public static IEnumerable<tbUserNote> GetUserNotes( IWebAgent webAgent, string subName)
+        public static IEnumerable<TBUserNote> GetUserNotes(IWebAgent webAgent, string subName)
         {
             var request = webAgent.CreateGet(String.Format(ToolBoxUserNotesWiki, subName));
             var reqResponse = webAgent.ExecuteRequest(request);
@@ -22,11 +22,10 @@ namespace RedditSharp
 
             string[] warnings = response["constants"]["warnings"].Values<string>().ToArray();
 
-            if (version < 6)
+            if (version < 6) throw new ToolBoxUserNotesException("Unsupported ToolBox version");
+
+            try
             {
-                throw new ToolBoxUserNotesException("Unsupported ToolBox version");
-            }
-            try {
                 var data = Convert.FromBase64String(response["blob"].Value<string>());
 
                 string uncompressed;
@@ -46,14 +45,14 @@ namespace RedditSharp
 
                 JObject users = JObject.Parse(uncompressed);
 
-                List<tbUserNote> toReturn = new List<tbUserNote>();
+                List<TBUserNote> toReturn = new List<TBUserNote>();
                 foreach (KeyValuePair<string, JToken> user in users)
                 {
                     var x = user.Value;
                     foreach (JToken note in x["ns"].Children())
                     {
 
-                        tbUserNote uNote = new tbUserNote();
+                        TBUserNote uNote = new TBUserNote();
                         uNote.AppliesToUsername = user.Key;
                         uNote.SubName = subName;
                         uNote.SubmitterIndex = note["m"].Value<int>();
@@ -69,17 +68,16 @@ namespace RedditSharp
                 }
                 return toReturn;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 throw new ToolBoxUserNotesException("An error occured while processing Usernotes wiki. See inner exception for details", e);
             }
-            
         }
-        public static string UnsquashLink(string subreddit,string permalink)
+        public static string UnsquashLink(string subreddit, string permalink)
         {
-
             var link = "https://reddit.com/r/" + subreddit + "/";
-            if (string.IsNullOrEmpty(permalink)) {
+            if (string.IsNullOrEmpty(permalink))
+            {
                 return link;
             }
             var linkParams = permalink.Split(',');
@@ -94,7 +92,6 @@ namespace RedditSharp
             {
                 link += "message/messages/" + linkParams[1];
             }
-
             return link;
         }
     }

--- a/RedditSharp/ToolBoxUserNotesException.cs
+++ b/RedditSharp/ToolBoxUserNotesException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedditSharp
+{
+    class ToolBoxUserNotesException : Exception
+    {
+        public ToolBoxUserNotesException()
+        {
+        }
+
+        public ToolBoxUserNotesException(string message)
+            : base(message)
+        {
+        }
+
+        public ToolBoxUserNotesException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/RedditSharp/tbUserNote.cs
+++ b/RedditSharp/tbUserNote.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedditSharp
+{
+    public class tbUserNote
+    {
+        public int NoteTypeIndex { get; set; }
+        public string NoteType { get; set; }
+        public string SubName { get; set; }
+        public string Submitter { get; set; }
+        public int SubmitterIndex { get; set; }
+        public string Message { get; set; }
+        public string AppliesToUsername { get; set; }
+        public string Url { get; set; }
+        private DateTime _timestamp;
+        public DateTime Timestamp
+        {
+            get { return _timestamp; }
+            set
+            {
+                _timestamp = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+            }
+        }
+    }
+}

--- a/RedditSharp/tbUserNote.cs
+++ b/RedditSharp/tbUserNote.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace RedditSharp
 {
-    public class tbUserNote
+    public class TBUserNote
     {
         public int NoteTypeIndex { get; set; }
         public string NoteType { get; set; }


### PR DESCRIPTION
Adds new classes to read and parse Moderator Toolbox UserNotes from the subreddit's wiki page.

Added property of Thing.Subreddit to access the UserNotes. 

Only works for newer versions of ToolBox notes, throws an exception if it finds an older version.

Could use more robust error handling, but it gets the job done, and if it can't parse it, the notes were most likely corrupted anyway.