### PR TITLE
Add ModPermissions property to Subreddit object

### DIFF
--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -92,6 +92,13 @@ namespace RedditSharp.Things
         public bool UserIsModerator { get; set; }
 
         /// <summary>
+        /// Property giving the moderator permissions of the logged in user on this subreddit.
+        /// </summary>
+        [JsonProperty("mod_permissions")]
+        [JsonConverter(typeof(ModeratorPermissionConverter))]
+        public ModeratorPermission ModPermissions { get; set; }
+
+        /// <summary>
         /// Property determining whether the current logged in user is banned from the subreddit.
         /// </summary>
         [JsonProperty("user_is_banned")]


### PR DESCRIPTION
Since it pulls the mod permissions up in /reddits/mine/moderator.json , adding this parameter makes it accessible for all subreddits you moderate without needing the "read" scope and looking them up individually.

Functions exactly like previously added property "UserIsModerator" since the JSON is already there.