### PR TITLE
Ignore case true while parsing mod action

### DIFF
--- a/RedditSharp/ModActionType.cs
+++ b/RedditSharp/ModActionType.cs
@@ -68,7 +68,7 @@ namespace RedditSharp
             }
             else
             {
-                return Enum.Parse(typeof(ModActionType), value);
+                return Enum.Parse(typeof(ModActionType), value, true);
             }
 
         }


### PR DESCRIPTION
Fixes issues parsing between C# casing and lower casing from JSON with ModActions