### PR TITLE
Implement compatibility for WebProxies

### DIFF
--- a/RedditSharp/AuthProvider.cs
+++ b/RedditSharp/AuthProvider.cs
@@ -98,7 +98,7 @@ namespace RedditSharp
             _webAgent.Cookies = new CookieContainer();
 
             var request = _webAgent.CreatePost(AccessUrl);
-
+            request.InitWebReqProxy();
             request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
             var stream = request.GetRequestStream();
 
@@ -145,7 +145,7 @@ namespace RedditSharp
             _webAgent.Cookies = new CookieContainer();
 
             var request = _webAgent.CreatePost(AccessUrl);
-
+            request.InitWebReqProxy();
             request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
             var stream = request.GetRequestStream();
 
@@ -173,7 +173,7 @@ namespace RedditSharp
         {
             string tokenType = isRefresh ? "refresh_token" : "access_token";
             var request = _webAgent.CreatePost(RevokeUrl);
-
+            request.InitWebReqProxy();
             request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.Default.GetBytes(_clientId + ":" + _clientSecret));
 
             var stream = request.GetRequestStream();
@@ -198,6 +198,7 @@ namespace RedditSharp
         public AuthenticatedUser GetUser(string accessToken)
         {
             var request = _webAgent.CreateGet(OauthGetMeUrl);
+            request.InitWebReqProxy();
             request.Headers["Authorization"] = String.Format("bearer {0}", accessToken);
             var response = (HttpWebResponse)request.GetResponse();
             var result = _webAgent.GetResponseString(response.GetResponseStream());

--- a/RedditSharp/HttpWebReqProxy.cs
+++ b/RedditSharp/HttpWebReqProxy.cs
@@ -1,0 +1,48 @@
+﻿
+using Microsoft.VisualBasic;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+
+namespace RedditSharp
+{
+    public static class HttpWebReqProxy
+    {
+        static bool proxyRequired = false;
+        static string proxyAddress = null;
+        static string proxyUsername = null;
+        static string proxyPassword = null;
+
+        public static void SetupWebRequestProxy(string proxAddress, string proxUsername, string proxPassword)
+        {
+            proxyRequired = true;
+            proxyAddress = proxAddress;
+            proxyUsername = proxUsername;
+            proxyPassword = proxPassword;
+        }
+
+        public static void DisableWebRequestProxy()
+        {
+            proxyRequired = false;
+            proxyAddress = null;
+            proxyUsername = null;
+            proxyPassword = null;
+        }
+
+
+        public static void InitWebReqProxy(this System.Net.HttpWebRequest req)
+        {
+            if (!proxyRequired) { return; }
+
+            System.Net.WebProxy myProxy = new System.Net.WebProxy();
+
+            myProxy.Address = new Uri(proxyAddress);
+            myProxy.Credentials = new System.Net.NetworkCredential(proxyUsername, proxyPassword);
+
+            req.Proxy = myProxy;
+        }
+
+    }
+}

--- a/RedditSharp/HttpWebReqProxy.cs
+++ b/RedditSharp/HttpWebReqProxy.cs
@@ -1,10 +1,4 @@
-﻿
-using Microsoft.VisualBasic;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
+﻿using System;
 
 namespace RedditSharp
 {

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -177,6 +177,7 @@ namespace RedditSharp
                 request = WebAgent.CreatePost(SslLoginUrl);
             else
                 request = WebAgent.CreatePost(LoginUrl);
+            request.InitWebReqProxy();
             var stream = request.GetRequestStream();
             if (useSsl)
             {
@@ -226,6 +227,7 @@ namespace RedditSharp
         public void InitOrUpdateUser()
         {
             var request = WebAgent.CreateGet(string.IsNullOrEmpty(WebAgent.AccessToken) ? MeUrl : OAuthMeUrl);
+            request.InitWebReqProxy();
             var response = (HttpWebResponse)request.GetResponse();
             var result = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JObject.Parse(result);
@@ -283,6 +285,7 @@ namespace RedditSharp
                 url = url.Remove(url.Length - 1);
 
             var request = WebAgent.CreateGet(string.Format(GetPostUrl, url));
+            request.InitWebReqProxy();
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JToken.Parse(data);
@@ -300,6 +303,7 @@ namespace RedditSharp
             if (User == null)
                 throw new Exception("User can not be null.");
             var request = WebAgent.CreatePost(ComposeMessageUrl);
+            request.InitWebReqProxy();
             WebAgent.WritePostBody(request.GetRequestStream(), new
             {
                 api_type = "json",
@@ -336,6 +340,7 @@ namespace RedditSharp
         public AuthenticatedUser RegisterAccount(string userName, string passwd, string email = "")
         {
             var request = WebAgent.CreatePost(RegisterAccountUrl);
+            request.InitWebReqProxy();
             WebAgent.WritePostBody(request.GetRequestStream(), new
             {
                 api_type = "json",
@@ -354,6 +359,7 @@ namespace RedditSharp
         public Thing GetThingByFullname(string fullname)
         {
             var request = WebAgent.CreateGet(string.Format(GetThingUrl, fullname));
+            request.InitWebReqProxy();
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JToken.Parse(data);
@@ -382,6 +388,7 @@ namespace RedditSharp
         {
             var url = string.Format(GetPostUrl, uri.AbsoluteUri);
             var request = WebAgent.CreateGet(url);
+            request.InitWebReqProxy();
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JToken.Parse(data);
@@ -459,6 +466,7 @@ namespace RedditSharp
         protected async internal Task<T> GetThingAsync<T>(string url) where T : Thing
         {
             var request = WebAgent.CreateGet(url);
+            request.InitWebReqProxy();
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JToken.Parse(data);
@@ -469,6 +477,7 @@ namespace RedditSharp
         protected internal T GetThing<T>(string url) where T : Thing
         {
             var request = WebAgent.CreateGet(url);
+            request.InitWebReqProxy();
             var response = request.GetResponse();
             var data = WebAgent.GetResponseString(response.GetResponseStream());
             var json = JToken.Parse(data);

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HttpWebReqProxy.cs" />
     <Compile Include="ModActionType.cs" />
     <Compile Include="Things\ModAction.cs" />
     <Compile Include="Utils\DateTimeExtensions.cs" />

--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -105,6 +105,7 @@ namespace RedditSharp
                     throw new Exception("Could not parse Uri");
             }
             var request = CreateGet(uri);
+            request.InitWebReqProxy();
             try { return ExecuteRequest(request); }
             catch (Exception)
             {
@@ -228,6 +229,7 @@ namespace RedditSharp
                 request = (HttpWebRequest)WebRequest.Create(String.Format("{0}://{1}{2}", Protocol, RootDomain, url));
             else
                 request = (HttpWebRequest)WebRequest.Create(url);
+            request.InitWebReqProxy();
             request.CookieContainer = Cookies;
             if (Type.GetType("Mono.Runtime") != null)
             {
@@ -247,6 +249,7 @@ namespace RedditSharp
         {
             EnforceRateLimit();
             var request = (HttpWebRequest)WebRequest.Create(uri);
+            request.InitWebReqProxy();
             request.CookieContainer = Cookies;
             if (Type.GetType("Mono.Runtime") != null)
             {
@@ -264,17 +267,22 @@ namespace RedditSharp
 
         public HttpWebRequest CreateGet(string url)
         {
-            return CreateRequest(url, "GET");
+            var request = CreateRequest(url, "GET");
+            request.InitWebReqProxy();
+            return request;
         }
 
         private HttpWebRequest CreateGet(Uri url)
         {
-            return CreateRequest(url, "GET");
+            var request = CreateRequest(url, "GET");
+            request.InitWebReqProxy();
+            return request;
         }
 
         public HttpWebRequest CreatePost(string url)
         {
             var request = CreateRequest(url, "POST");
+            request.InitWebReqProxy();
             request.ContentType = "application/x-www-form-urlencoded";
             return request;
         }


### PR DESCRIPTION
Adds an implementation that allows users to configure a `WebProxy` that will be used for all requests. Addresses issue #51. 

To use, call this method at start:
```cs
RedditSharp.HttpWebReqProxy.SetupWebRequestProxy("http://proxyaddress", "domain\\username", "password");
```

Can also disable the proxy configuration settings later by calling `RedditSharp.HttpWebReqProxy.DisableWebRequestProxy();`

I *think* I hit all of the places where `System.Net.HttpWebRequest` are created and used (if I missed any, I haven't caught it in my initial testing).

&nbsp;

---

(Note: C# isn't my primary language of experience, so I apologize if there are any *faux pas* that I've made. Let me know if there's anything I should change or fix.)