### PR TITLE
Fixed long response times for requests made to reddit

### DIFF
--- a/RedditSharp/WebAgent.cs
+++ b/RedditSharp/WebAgent.cs
@@ -240,6 +240,7 @@ namespace RedditSharp
             }
             request.Method = method;
             request.UserAgent = UserAgent + " - with RedditSharp by /u/sircmpwn";
+            request.Headers.Add(HttpRequestHeader.AcceptLanguage, "en-US,en;q=0.8");
             return request;
         }
 
@@ -259,6 +260,7 @@ namespace RedditSharp
             }
             request.Method = method;
             request.UserAgent = UserAgent + " - with RedditSharp by /u/sircmpwn";
+            request.Headers.Add(HttpRequestHeader.AcceptLanguage, "en-US,en;q=0.8");
             return request;
         }
 


### PR DESCRIPTION
Reddit servers seem to throw a fit if you don't specify both a `UserAgent` and an `AcceptLanguage` in the requests. For me, this results in very long responses that took 5-10 seconds for a request. 

Using Fiddler, I was able to determine that the timeout was taking place between `ServerGotRequest` and `ServerBeginResponse`, so that's when I tried modifying the header until I pinpointed what was causing the long delays. 

If others are having similar delays as me, this change makes a world of difference.